### PR TITLE
fix "bad substiution" error when running autogen.sh

### DIFF
--- a/util/gitdesc.sh
+++ b/util/gitdesc.sh
@@ -47,9 +47,7 @@ tagopt="--tags"
 # v#.#.#-#-g#######
 init() {
 	if [ -d '.git' ] ; then
-		describe_tag=$(git describe $tagopt --long --abbrev=7)
-		describe_tag=${describe_tag/v/}
-		describe_tag=${describe_tag/g/}
+		describe_tag=$(git describe $tagopt --long --abbrev=7 | sed -E 's/^v(.*?-)g(.*)$/\1\2/')
 		commit=$(echo $describe_tag | cut -d- -f3)
 		tagrev=$(echo $describe_tag | cut -d- -f2)
 		version=$(echo $describe_tag | cut -d- -f1)


### PR DESCRIPTION
As reported in https://github.com/pete4abw/lrzip-next/issues/18#issuecomment-810201365

The syntax used in utils/gitdesc.sh works when using my local bash shell but fails when using sh