### PR TITLE
bzip3 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,8 @@ AC_CHECK_LIB(bz2, BZ2_bzBuffToBuffCompress, ,
         AC_MSG_ERROR([Could not find bz2 library - please install libbz2-dev]))
 AC_CHECK_LIB(lzo2, lzo1x_1_compress, ,
         AC_MSG_ERROR([Could not find lzo2 library - please install liblzo2-dev]))
+AC_CHECK_LIB(bzip3, bz3_encode_block, ,
+        AC_MSG_ERROR([Could not find bzip3 library - please install bzip3]))
 AC_CHECK_LIB(lz4, LZ4_compress_default, ,
 	AC_MSG_ERROR([Could not find lz4 library - please install liblz4-dev]))
 AC_CHECK_LIB(gpg-error, gpg_err_code_to_errno, ,

--- a/src/include/lrzip_private.h
+++ b/src/include/lrzip_private.h
@@ -278,6 +278,7 @@ static inline unsigned char lzma2_prop_from_dic(u32 dicSize)
 #define FLAG_TMP_OUTBUF		(1 << 21)
 #define FLAG_TMP_INBUF		(1 << 22)
 #define FLAG_ENCRYPT		(1 << 23)
+#define FLAG_BZIP3_COMPRESS	(1 << 24)
 
 #define NO_HASH		(!(HASH_CHECK) && !(HAS_HASH))
 
@@ -287,6 +288,7 @@ static inline unsigned char lzma2_prop_from_dic(u32 dicSize)
 #define CTYPE_LZMA 6
 #define CTYPE_GZIP 7
 #define CTYPE_ZPAQ 8
+#define CTYPE_BZIP3 9
 
 #define PASS_LEN 512
 #define HASH_LEN 64
@@ -328,7 +330,7 @@ static inline unsigned char lzma2_prop_from_dic(u32 dicSize)
 #define ARBITRARY_AT_EPOCH (ARBITRARY * pow (MOORE_TIMES_PER_SECOND, -T_ZERO))
 
 #define FLAG_VERBOSE (FLAG_VERBOSITY | FLAG_VERBOSITY_MAX)
-#define FLAG_NOT_LZMA (FLAG_NO_COMPRESS | FLAG_LZO_COMPRESS | FLAG_BZIP2_COMPRESS | FLAG_ZLIB_COMPRESS | FLAG_ZPAQ_COMPRESS)
+#define FLAG_NOT_LZMA (FLAG_NO_COMPRESS | FLAG_LZO_COMPRESS | FLAG_BZIP2_COMPRESS | FLAG_ZLIB_COMPRESS | FLAG_ZPAQ_COMPRESS | FLAG_BZIP3_COMPRESS)
 #define LZMA_COMPRESS	(!(control->flags & FLAG_NOT_LZMA))
 
 #define SHOW_PROGRESS	(control->flags & FLAG_SHOW_PROGRESS)
@@ -341,6 +343,7 @@ static inline unsigned char lzma2_prop_from_dic(u32 dicSize)
 #define BZIP2_COMPRESS	(control->flags & FLAG_BZIP2_COMPRESS)
 #define ZLIB_COMPRESS	(control->flags & FLAG_ZLIB_COMPRESS)
 #define ZPAQ_COMPRESS	(control->flags & FLAG_ZPAQ_COMPRESS)
+#define BZIP3_COMPRESS	(control->flags & FLAG_BZIP3_COMPRESS)
 #define VERBOSE		(control->flags & FLAG_VERBOSE)
 #define VERBOSITY	(control->flags & FLAG_VERBOSITY)
 #define MAX_VERBOSE	(control->flags & FLAG_VERBOSITY_MAX)
@@ -479,6 +482,7 @@ struct rzip_control {
 	u32 dictSize;			// lzma Dictionary size - set in overhead computation
 	unsigned zpaq_level;		// zpaq level
 	unsigned zpaq_bs;		// zpaq default block size
+	unsigned bzip3_bs;      // bzip3 block size
 	i64 window;
 	unsigned long flags;
 	i64 ramsize;

--- a/src/util.c
+++ b/src/util.c
@@ -164,6 +164,28 @@ void setup_overhead(rzip_control *control)
 			}
 		}
 		control->overhead = (i64) (1 << control->zpaq_bs) * ONE_MB;	// times 8 or 16. Out for now
+	} else if(BZIP3_COMPRESS) {
+		if(control->bzip3_bs == 0) {
+			switch (control->compression_level) {
+			case 1:
+			case 2:
+			case 3: control->bzip3_bs = 4;
+				break;  //16MB BZIP3 Default
+			case 4:
+			case 5:	control->bzip3_bs = 5;
+				break;	//32MB
+			case 6:	control->bzip3_bs = 6;
+				break;	//64MB
+			case 7:	control->bzip3_bs = 7;
+				break;	//128MB
+			case 8: case 9:	control->bzip3_bs = 8;
+				break;	//256MB
+			default: control->bzip3_bs = 4;
+				break;	// should never reach here
+			}
+		}
+
+		control->overhead = (i64) (1 << control->bzip3_bs) * ONE_MB * 8;
 	}
 
 	/* no need for zpaq computation here. do in open_stream_out() */
@@ -276,6 +298,8 @@ bool read_config(rzip_control *control)
 				control->flags |= FLAG_NO_COMPRESS;
 			else if (isparameter(parametervalue, "zpaq"))
 				control->flags |= FLAG_ZPAQ_COMPRESS;
+			else if (isparameter(parametervalue, "bzip3"))
+				control->flags |= FLAG_BZIP3_COMPRESS;
 			else if (!isparameter(parametervalue, "lzma")) /* oops, not lzma! */
 				fatal("CONF.FILE error. Invalid compression method %s specified\n", parametervalue);
 		}


### PR DESCRIPTION
## Rationale

bzip3 is a spiritual successor to bzip2. Generally features better compression ratio, and from my tests, is a valuable addition to lrzip. Since the upstream maintainer of lrzip didn't want to merge my code claiming that while bzip3 seems to be a good codec because lrzip is in maintenance mode, I am submitting the pull request here hoping that it gets merged.

[The upstream repository has some benchmarks including lrzip already](https://github.com/kspalaiologos/bzip3), however, I have prepared a set of benchmarks now that bzip3 is implemented in lrzip-next.

## Benchmarks

I started with 824MB of GCC code in a TAR file:

```
% src/lrzip-next -L 9 -B ~/Desktop/gcc.tar
/home/palaiologos/Desktop/gcc.tar - Compression Ratio: 10.152. bpb: 0.788. Average Compression Speed: 34.174MB/s.
Total time: 00:00:23.92

% src/lrzip-next -L 9 -b ~/Desktop/gcc.tar
/home/palaiologos/Desktop/gcc.tar - Compression Ratio: 8.746. bpb: 0.915. Average Compression Speed: 35.727MB/s.
Total time: 00:00:22.52

% src/lrzip-next -L 9 ~/Desktop/gcc.tar
/home/palaiologos/Desktop/gcc.tar - Compression Ratio: 9.955. bpb: 0.804. Average Compression Speed: 12.476MB/s.
Total time: 00:01:02.50

% src/lrzip-next -L 9 -g ~/Desktop/gcc.tar -o ~/Desktop/gcc-gzip.tar.lrz
LZ4 Threshold testing disabled due to Filtering and/or Compression type (gzip, lzo, rzip).
/home/palaiologos/Desktop/gcc.tar - Compression Ratio: 7.161. bpb: 1.117. Average Compression Speed: 35.727MB/s.
Total time: 00:00:22.23

src/lrzip-next -L 9 -z ~/Desktop/gcc.tar -o ~/Desktop/gcc-zp.tar.lrz
/home/palaiologos/Desktop/gcc.tar - Compression Ratio: 12.759. bpb: 0.627. Average Compression Speed:  2.787MB/s.
Total time: 00:04:42.21
```

Decompression:

```
% src/lrzip-next -d ~/Desktop/gcc-bz3.tar.lrz
Output filename is: /home/palaiologos/Desktop/gcc-bz3.tar
Validating file for consistency...[OK]
100%     786.12 /    786.12 MB0 /    786.12 MB
Average DeCompression Speed: 78.600MB/s
MD5:2374ee8022d06e75247cc4b691d79b01
Output filename is: /home/palaiologos/Desktop/gcc-bz3.tar: [OK] - 824,309,760 bytes
Total time: 00:00:09.29

% src/lrzip-next -d ~/Desktop/gcc-bz2.tar.lrz
Output filename is: /home/palaiologos/Desktop/gcc-bz2.tar
Validating file for consistency...[OK]
100%     786.12 /    786.12 MB0 /    786.12 MB
Average DeCompression Speed: 157.200MB/s
MD5:2374ee8022d06e75247cc4b691d79b01
Output filename is: /home/palaiologos/Desktop/gcc-bz2.tar: [OK] - 824,309,760 bytes
Total time: 00:00:04.88

% src/lrzip-next -d ~/Desktop/gcc-lzma.tar.lrz
Output filename is: /home/palaiologos/Desktop/gcc-lzma.tar
Validating file for consistency...[OK]
100%     786.12 /    786.12 MB0 /    786.12 MB
Average DeCompression Speed: 196.500MB/s
MD5:2374ee8022d06e75247cc4b691d79b01
Output filename is: /home/palaiologos/Desktop/gcc-lzma.tar: [OK] - 824,309,760 bytes
Total time: 00:00:03.40

% src/lrzip-next -d ~/Desktop/gcc-gzip.tar.lrz
Output filename is: /home/palaiologos/Desktop/gcc-gzip.tar
Validating file for consistency...[OK]
100%     786.12 /    786.12 MB0 /    786.12 MB
Average DeCompression Speed: 393.000MB/s
MD5:2374ee8022d06e75247cc4b691d79b01
Output filename is: /home/palaiologos/Desktop/gcc-gzip.tar: [OK] - 824,309,760 bytes
Total time: 00:00:02.37
```

Sizes:

```
 94245430 /home/palaiologos/Desktop/gcc-bz2.tar.lrz
 81193479 /home/palaiologos/Desktop/gcc-bz3.tar.lrz
115108636 /home/palaiologos/Desktop/gcc-gzip.tar.lrz
 82805563 /home/palaiologos/Desktop/gcc-lzma.tar.lrz
 64603777 /home/palaiologos/Desktop/gcc-zp.tar.lrz
```

While this benchmark might not be the most representative one for various reasons (small amounts of redundancy, etc...), I don't have the circumstances to reproduce the original benchmark in the source code trunk.

A mention of bzip3 should probably go to the manpages and there might be some issues at the very moment, however, I plan to iron them all out eventually.