### PR TITLE
Allow decompression with files compressed under lrzip-next 0.13.0

### DIFF
--- a/src/lrzip.c
+++ b/src/lrzip.c
@@ -826,6 +826,9 @@ static bool read_tmpinmagic(rzip_control *control, int fd_in)
 			case 12:
 				bytes_to_read = MAGIC_LEN;
 				break;
+			case 13:
+				bytes_to_read = MAGIC_LEN;
+				break;
 			default:
 				fatal("Unknown lrzip-next version %d. Aborting...\n", magic[5]);
 				break;

--- a/src/lrzip.c
+++ b/src/lrzip.c
@@ -824,8 +824,6 @@ static bool read_tmpinmagic(rzip_control *control, int fd_in)
 				break;
 			case 11:
 			case 12:
-				bytes_to_read = MAGIC_LEN;
-				break;
 			case 13:
 				bytes_to_read = MAGIC_LEN;
 				break;


### PR DESCRIPTION
First of all, thanks so much for this amazing fork! I've been following the main lrzip for a while, but I now prefer this because it supports zstd. Regardless, I encountered an error when attempting to decompress a file that I had just compressed (to test integrity) under lrzip-next 0.13.0:
```
$ tar -I "lrzip-next --zstd -v" -xf test.tar.lrz ./test
The following options are in effect for this DECOMPRESSION.
Threading is ENABLED. Number of CPUs detected: 4
Detected 25206579200 bytes ram
Nice Value: 19
Show Progress
Verbose
Temporary Directory set as: /tmp/
Unknown lrzip-next version 13. Aborting...
Fatal error - exiting
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```
I'm not sure if this error was caused by an interaction with zstd and lrzip-next 0.13.0, or if it would affect anything without zstd, but adding these three lines and recompiling fixed it for me.